### PR TITLE
add GitHub workflow for tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,27 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  tests:
+    name: ${{ matrix.nox-session }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nox-session: ['tests', 'style', 'docs']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('setup.py') }}-${ hashFiles('requirements/*.txt') }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - uses: excitedleigh/setup-nox@0.1.0
+      - run: nox -s ${{ matrix.nox-session }}


### PR DESCRIPTION
closes #4 

This runs three different jobs: tests, style, and docs. Tests could be broken out by Python version, can do that later if it starts getting confusing or slow.