### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="magql",
     install_requires=[
-        "GraphQL-core-next",
+        "graphql-core>=3",
         "inflection",
         "marshmallow<3",
         "marshmallow-sqlalchemy",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ setup(
     name="magql",
     install_requires=[
         "graphql-core>=3",
-        "inflection",
-        "SQLAlchemy",
-        "SQLAlchemy-Utils",
+        "inflection>=0.3",
+        "SQLAlchemy>=1.3",
+        "SQLAlchemy-Utils>=0.35",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ setup(
     install_requires=[
         "graphql-core>=3",
         "inflection",
-        "marshmallow<3",
-        "marshmallow-sqlalchemy",
         "SQLAlchemy",
         "SQLAlchemy-Utils",
     ],

--- a/src/magql/resolver_factory.py
+++ b/src/magql/resolver_factory.py
@@ -335,9 +335,6 @@ class ModelInputResolver(MutationResolver):
         """
         MutationResolver can be overriden by
         :param table:
-        :param schema: Optional, by default it is a generic Marshmallow
-        schema that is automatically generated based on the table by
-        Marshmallow-SQLAlchemy.
         """
         super().__init__(table)
 

--- a/src/magql/validator.py
+++ b/src/magql/validator.py
@@ -1,29 +1,3 @@
-from collections import defaultdict
-
-from marshmallow_sqlalchemy import field_for
-
-validator_overrides = defaultdict(lambda: {})
-
-
-def get_validator_overrides(model):
-    return validator_overrides[model].copy()
-
-
-def validator(model, field_name):
-    def validator_decorator(validator_function):
-        # tuple key/ value pair or nested?
-        validator_overrides[model][field_name] = field_for(
-            model, field_name, validate=validator_function
-        )
-
-        def validate(*args, **kwargs):
-            return validator_function(*args, **kwargs)
-
-        return validate
-
-    return validator_decorator
-
-
 class ValidationFailedError(Exception):
     def __init__(self, errors):
         if not isinstance(errors, list):


### PR DESCRIPTION
* Use graphql-core instead of graphql-core-next. No code changes. fixes #2 
* Remove marshmallow and marshmallow-sqlalchemy. Removed some unused code and docs. fixes #3 
* Set minimum versions of dependencies. This sets some expectations for what we're supporting. If we need a feature from a later version in the future, the minimum should be increased.