### PR TITLE
Add pagination support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ v0.4.0
 
 Unreleased
 
+-   Add pagination support. :pr:`20`
 -   Add ``AuthorizationError`` and remove ``PermissionsError``.
     :issue:`23`
 -   Add ``ListPayload`` type for list return types. :pr:`15`

--- a/src/magql/definitions.py
+++ b/src/magql/definitions.py
@@ -3,7 +3,6 @@ from functools import wraps
 from graphql import GraphQLArgument
 from graphql import GraphQLBoolean
 from graphql import GraphQLEnumType
-from graphql import GraphQLError
 from graphql import GraphQLField
 from graphql import GraphQLFloat
 from graphql import GraphQLID
@@ -13,11 +12,8 @@ from graphql import GraphQLInt
 from graphql import GraphQLList
 from graphql import GraphQLNonNull
 from graphql import GraphQLObjectType
-from graphql import GraphQLScalarType
 from graphql import GraphQLString
 from graphql import GraphQLUnionType
-from graphql.language.ast import IntValueNode
-from graphql.pyutils import is_integer
 from graphql.type.scalars import coerce_float
 from graphql.type.scalars import coerce_int
 from inflection import camelize
@@ -288,62 +284,3 @@ class MagqlString:
 class MagqlID:
     def convert(self, type_map):
         return GraphQLID
-
-
-class MagqlCustomScalar:
-    def convert(self, type_map):
-        if self.name in type_map:
-            return type_map[self.name]
-        type_map[self.name] = GraphQLScalarType(
-            name=self.name,
-            description=self.description,
-            serialize=self.serialize,
-            parse_literal=self.parse_literal,
-            parse_value=self.parse_value,
-        )
-        return type_map[self.name]
-
-
-class MagqlCustomInt(MagqlCustomScalar):
-    def __init__(self, min_int, max_int):
-        self.name = "PositiveInteger"
-        self.description = "A custom integer type with defined min and max values."
-        self.min_int = min_int
-        self.max_int = max_int
-
-    def serialize(self, output_value):
-        if isinstance(output_value, bool):
-            return 1 if output_value else 0
-        try:
-            if isinstance(output_value, int):
-                num = output_value
-            elif isinstance(output_value, float):
-                num = int(output_value)
-                if num != output_value:
-                    raise ValueError
-            elif not output_value and isinstance(output_value, str):
-                output_value = ""
-                raise ValueError
-            else:
-                num = int(output_value)  # raises ValueError if not an integer
-        except (OverflowError, ValueError, TypeError):
-            raise GraphQLError("Int cannot represent non-integer value")
-        if not self.min_int <= num <= self.max_int:
-            raise ValueError()
-        return num
-
-    def parse_value(self, input_value):
-        if not is_integer(input_value):
-            raise GraphQLError("Int cannot represent non-integer value")
-        if not self.min_int <= input_value <= self.max_int:
-            raise ValueError()
-        return int(input_value)
-
-    def parse_literal(self, value_node, _variables=None):
-        """Parse an integer value node in the AST."""
-        if not isinstance(value_node, IntValueNode):
-            raise GraphQLError("Int cannot represent non-integer value: ")
-        num = int(value_node.value)
-        if not self.min_int <= num <= self.max_int:
-            raise ValueError()
-        return num

--- a/src/magql/definitions.py
+++ b/src/magql/definitions.py
@@ -291,13 +291,6 @@ class MagqlID:
 
 
 class MagqlCustomScalar:
-    def __init__(self, name, description):
-        self.name = name
-        self.description = description
-        self.serialize = self.serialize
-        self.parse_value = self.parse_value
-        self.parse_literal = self.parse_literal
-
     def convert(self, type_map):
         if self.name in type_map:
             return type_map[self.name]
@@ -313,13 +306,10 @@ class MagqlCustomScalar:
 
 class MagqlCustomInt(MagqlCustomScalar):
     def __init__(self, min_int, max_int):
-        self.name = "CustomInt"
+        self.name = "PositiveInteger"
         self.description = "A custom integer type with defined min and max values."
         self.min_int = min_int
         self.max_int = max_int
-        super().__init__(
-            self.name, self.description,
-        )
 
     def serialize(self, output_value):
         if isinstance(output_value, bool):
@@ -339,14 +329,14 @@ class MagqlCustomInt(MagqlCustomScalar):
         except (OverflowError, ValueError, TypeError):
             raise GraphQLError("Int cannot represent non-integer value")
         if not self.min_int <= num <= self.max_int:
-            raise GraphQLError("Int cannot represent non 32-bit signed integer value")
+            raise ValueError()
         return num
 
     def parse_value(self, input_value):
         if not is_integer(input_value):
             raise GraphQLError("Int cannot represent non-integer value")
         if not self.min_int <= input_value <= self.max_int:
-            raise GraphQLError("Int cannot represent non 32-bit signed integer value: ")
+            raise ValueError()
         return int(input_value)
 
     def parse_literal(self, value_node, _variables=None):
@@ -355,5 +345,5 @@ class MagqlCustomInt(MagqlCustomScalar):
             raise GraphQLError("Int cannot represent non-integer value: ")
         num = int(value_node.value)
         if not self.min_int <= num <= self.max_int:
-            raise GraphQLError("Int cannot represent non 32-bit signed integer value: ")
+            raise ValueError()
         return num

--- a/src/magql/definitions.py
+++ b/src/magql/definitions.py
@@ -291,12 +291,12 @@ class MagqlID:
 
 
 class MagqlCustomScalar:
-    def __init__(self, name, description, serialize, parse_value, parse_literal):
+    def __init__(self, name, description):
         self.name = name
         self.description = description
-        self.serialize = serialize
-        self.parse_value = parse_value
-        self.parse_literal = parse_literal
+        self.serialize = self.serialize
+        self.parse_value = self.parse_value
+        self.parse_literal = self.parse_literal
 
     def convert(self, type_map):
         if self.name in type_map:
@@ -314,15 +314,11 @@ class MagqlCustomScalar:
 class MagqlCustomInt(MagqlCustomScalar):
     def __init__(self, min_int, max_int):
         self.name = "CustomInt"
-        self.description = "description"
+        self.description = "A custom integer type with defined min and max values."
         self.min_int = min_int
         self.max_int = max_int
         super().__init__(
-            self.name,
-            self.description,
-            self.serialize,
-            self.parse_value,
-            self.parse_literal,
+            self.name, self.description,
         )
 
     def serialize(self, output_value):

--- a/src/magql/manager.py
+++ b/src/magql/manager.py
@@ -6,6 +6,7 @@ from sqlalchemy_utils import get_mapper
 
 from magql.definitions import js_camelize
 from magql.definitions import MagqlArgument
+from magql.definitions import MagqlCustomInt
 from magql.definitions import MagqlEnumType
 from magql.definitions import MagqlField
 from magql.definitions import MagqlInputField
@@ -124,10 +125,14 @@ class MagqlTableManagerCollection:
         self.manager_map["checkDelete"] = check_delete_manager
 
     def generate_pagination(self):
+        custom_int = MagqlCustomInt(min_int=0, max_int=5)
         page_manager = MagqlManager("PaginationManager")
         page_manager.magql_types["PageObject"] = MagqlInputObjectType(
             "PageObject",
-            {"page_num": MagqlInputField("Int"), "per_page": MagqlInputField("Int")},
+            {
+                "page_num": MagqlInputField(custom_int),
+                "per_page": MagqlInputField(custom_int),
+            },
         )
         self.manager_map["PaginationManager"] = page_manager
 

--- a/src/magql/manager.py
+++ b/src/magql/manager.py
@@ -125,13 +125,13 @@ class MagqlTableManagerCollection:
         self.manager_map["checkDelete"] = check_delete_manager
 
     def generate_pagination(self):
-        custom_int = MagqlCustomInt(min_int=0, max_int=5)
+        page_int = MagqlCustomInt(min_int=0, max_int=100)
         page_manager = MagqlManager("PaginationManager")
         page_manager.magql_types["PageObject"] = MagqlInputObjectType(
             "PageObject",
             {
-                "page_num": MagqlInputField(custom_int),
-                "per_page": MagqlInputField(custom_int),
+                "page_num": MagqlInputField(page_int),
+                "per_page": MagqlInputField(page_int),
             },
         )
         self.manager_map["PaginationManager"] = page_manager

--- a/src/magql/manager.py
+++ b/src/magql/manager.py
@@ -17,6 +17,7 @@ from magql.definitions import MagqlUnionType
 from magql.filter import RelFilter
 from magql.resolver_factory import CamelResolver
 from magql.resolver_factory import CheckDeleteResolver
+from magql.resolver_factory import CountResolver
 from magql.resolver_factory import CreateResolver
 from magql.resolver_factory import DeleteResolver
 from magql.resolver_factory import EnumResolver
@@ -92,6 +93,7 @@ class MagqlTableManagerCollection:
 
         self.magql_name_to_table = {}
         self.generate_check_delete()
+        self.generate_pagination()
 
     def generate_check_delete(self):
         check_delete_manager = MagqlManager("checkDelete")
@@ -120,6 +122,14 @@ class MagqlTableManagerCollection:
             CheckDeleteResolver(list(self.magql_name_to_table.values())),
         )
         self.manager_map["checkDelete"] = check_delete_manager
+
+    def generate_pagination(self):
+        page_manager = MagqlManager("PaginationManager")
+        page_manager.magql_types["PageObject"] = MagqlInputObjectType(
+            "PageObject",
+            {"page": MagqlInputField("Int"), "per_page": MagqlInputField("Int")},
+        )
+        self.manager_map["PaginationManager"] = page_manager
 
     def generate_manager(self, table):
         try:
@@ -286,6 +296,7 @@ class MagqlTableManager(MagqlManager):
                 "sort": MagqlArgument(
                     MagqlList(MagqlNonNull(self.magql_name + "Sort"))
                 ),
+                "pagination": MagqlArgument("PageObject"),
             },
             self.many_resolver,
         )
@@ -441,6 +452,7 @@ class MagqlTableManager(MagqlManager):
                     "result": MagqlField(
                         MagqlList(self.magql_name), None, ResultResolver()
                     ),
+                    "count": MagqlField("Int", None, CountResolver()),
                 },
             )
         )

--- a/src/magql/manager.py
+++ b/src/magql/manager.py
@@ -6,11 +6,11 @@ from sqlalchemy_utils import get_mapper
 
 from magql.definitions import js_camelize
 from magql.definitions import MagqlArgument
-from magql.definitions import MagqlCustomInt
 from magql.definitions import MagqlEnumType
 from magql.definitions import MagqlField
 from magql.definitions import MagqlInputField
 from magql.definitions import MagqlInputObjectType
+from magql.definitions import MagqlInt
 from magql.definitions import MagqlList
 from magql.definitions import MagqlNonNull
 from magql.definitions import MagqlObjectType
@@ -125,13 +125,12 @@ class MagqlTableManagerCollection:
         self.manager_map["checkDelete"] = check_delete_manager
 
     def generate_pagination(self):
-        page_int = MagqlCustomInt(min_int=0, max_int=100)
         page_manager = MagqlManager("PaginationManager")
-        page_manager.magql_types["PageObject"] = MagqlInputObjectType(
-            "PageObject",
+        page_manager.magql_types["Page"] = MagqlInputObjectType(
+            "Page",
             {
-                "page_num": MagqlInputField(page_int),
-                "per_page": MagqlInputField(page_int),
+                "current": MagqlInputField(MagqlInt()),
+                "per_page": MagqlInputField(MagqlInt()),
             },
         )
         self.manager_map["PaginationManager"] = page_manager
@@ -301,7 +300,7 @@ class MagqlTableManager(MagqlManager):
                 "sort": MagqlArgument(
                     MagqlList(MagqlNonNull(self.magql_name + "Sort"))
                 ),
-                "page": MagqlArgument("PageObject"),
+                "page": MagqlArgument("Page"),
             },
             self.many_resolver,
         )

--- a/src/magql/manager.py
+++ b/src/magql/manager.py
@@ -127,7 +127,7 @@ class MagqlTableManagerCollection:
         page_manager = MagqlManager("PaginationManager")
         page_manager.magql_types["PageObject"] = MagqlInputObjectType(
             "PageObject",
-            {"page": MagqlInputField("Int"), "per_page": MagqlInputField("Int")},
+            {"page_num": MagqlInputField("Int"), "per_page": MagqlInputField("Int")},
         )
         self.manager_map["PaginationManager"] = page_manager
 
@@ -296,7 +296,7 @@ class MagqlTableManager(MagqlManager):
                 "sort": MagqlArgument(
                     MagqlList(MagqlNonNull(self.magql_name + "Sort"))
                 ),
-                "pagination": MagqlArgument("PageObject"),
+                "page": MagqlArgument("PageObject"),
             },
             self.many_resolver,
         )

--- a/src/magql/resolver_factory.py
+++ b/src/magql/resolver_factory.py
@@ -609,8 +609,11 @@ class ManyResolver(QueryResolver):
         paginated = False
 
         try:
-            page = abs(info.variable_values["page"]["page_num"])
-            per_page = abs(info.variable_values["page"]["per_page"])
+            current = info.variable_values["page"]["current"]
+            per_page = info.variable_values["page"]["per_page"]
+            offset = current * per_page
+            if current < 0 or per_page < 0:
+                raise ValueError("Page inputs must be positive")
             paginated = True
         except KeyError:
             pass
@@ -631,7 +634,7 @@ class ManyResolver(QueryResolver):
         for option in options:
             query = query.options(option)
         if paginated:
-            return query.limit(per_page).offset(page), count
+            return query.limit(per_page).offset(offset), count
         return query, None
 
     def retrieve_value(self, parent, info, *args, **kwargs):

--- a/src/magql/resolver_factory.py
+++ b/src/magql/resolver_factory.py
@@ -610,15 +610,12 @@ class ManyResolver(QueryResolver):
 
         if info.variable_values.get("page") is not None:
             paginated = True
-            try:
-                current = info.variable_values.get("page").get("current")
-                per_page = info.variable_values.get("page").get("per_page")
-                if current is None or current < 1:
-                    current = 1
-                if per_page is None or per_page < 1:
-                    per_page = 10
-            except KeyError:
-                pass
+            current = info.variable_values.get("page").get("current")
+            per_page = info.variable_values.get("page").get("per_page")
+            if current is None or current < 1:
+                current = 1
+            if per_page is None or per_page < 1:
+                per_page = 10
 
         field_name = info.field_name
         field_node = [

--- a/src/magql/resolver_factory.py
+++ b/src/magql/resolver_factory.py
@@ -608,15 +608,17 @@ class ManyResolver(QueryResolver):
         """
         paginated = False
 
-        try:
-            current = info.variable_values["page"]["current"]
-            per_page = info.variable_values["page"]["per_page"]
-            offset = current * per_page
-            if current < 0 or per_page < 0:
-                raise ValueError("Page inputs must be positive")
+        if info.variable_values.get("page") is not None:
             paginated = True
-        except KeyError:
-            pass
+            try:
+                current = info.variable_values.get("page").get("current")
+                per_page = info.variable_values.get("page").get("per_page")
+                if current is None or current < 1:
+                    current = 1
+                if per_page is None or per_page < 1:
+                    per_page = 10
+            except KeyError:
+                pass
 
         field_name = info.field_name
         field_node = [
@@ -634,6 +636,7 @@ class ManyResolver(QueryResolver):
         for option in options:
             query = query.options(option)
         if paginated:
+            offset = (current - 1) * per_page
             return query.limit(per_page).offset(offset), count
         return query, None
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,7 @@ import pytest
 from graphql import execute
 from graphql import parse
 
+from .conftest import Car
 from magql.convert import Convert
 
 query = """
@@ -24,6 +25,17 @@ query test {
 }
 """
 
+query_pagination = """
+query test($page: Page) {
+  cars (page: $page){
+    result {
+      name
+    }
+    count
+  }
+}
+"""
+
 
 @pytest.fixture
 def schema(manager_collection):
@@ -37,3 +49,57 @@ def test_schema(session, schema):
     assert result.data["people"]["result"][0]["name"] == "Person 1"
     assert result.data["cars"]["result"][0]["name"] == "Car 1"
     assert result.data["houses"]["result"][0]["name"] == "House 1"
+
+
+def test_page(session, schema):
+    def generate_page(current, per):
+        return {"page": {"current": current, "per_page": per}}
+
+    car2 = Car(name="Car 2")
+    car3 = Car(name="Car 3")
+    session.add(car2)
+    session.add(car3)
+    session.commit()
+
+    document = parse(query_pagination)
+
+    # first page, one per page
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(0, 1)
+    )
+    assert len(result.data["cars"]["result"]) == 1
+    assert result.data["cars"]["result"][0]["name"] == "Car 1"
+    assert result.data["cars"]["count"] == 3
+
+    # second page, one per page
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(1, 1)
+    )
+    assert len(result.data["cars"]["result"]) == 1
+    assert result.data["cars"]["result"][0]["name"] == "Car 2"
+    assert result.data["cars"]["count"] == 3
+
+    # first page, two per page
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(0, 2)
+    )
+    assert len(result.data["cars"]["result"]) == 2
+    assert result.data["cars"]["count"] == 3
+
+    # bad page, -2 per page
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(0, -2)
+    )
+    assert result.errors[0].message == "Page inputs must be positive"
+
+    # ask for a page # greater than total count
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(5, 1)
+    )
+    assert len(result.data["cars"]["result"]) == 0
+
+    # ask for current, per_page that exceeds total count
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(2, 5)
+    )
+    assert len(result.data["cars"]["result"]) == 0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -103,3 +103,9 @@ def test_page(session, schema):
         schema, document, context_value=session, variable_values=generate_page(2, 5)
     )
     assert len(result.data["cars"]["result"]) == 0
+
+    # ask for per_page that exceeds total count
+    result = execute(
+        schema, document, context_value=session, variable_values=generate_page(0, 100)
+    )
+    assert len(result.data["cars"]["result"]) == 3


### PR DESCRIPTION
Resolves #13.

Page object looks like:
```
{
   "page": {
         "per_page": 1
         "current": 1
   }
}
```
Inputs should be greater than 1 for per_page and page_num. 
Inputs for per_page/page_num that exceed total model count will return an empty result.
Negative inputs will default to 1 for current, and 10 for per_page.

A page object can also be submitted as an empty dictionary
```
{
   "page": {}
}
```
This results in a pagination query with current and per_page set to the above defaults of 1 and 10.

A new field, `count` is returned in the top level under the queryName. This is the total amount of models for the many query. 
A last page can be calculated with (count/per_page) and adding 1 if there is a remainder.

Example GraphQL query:
```
query models($filter: ModelFilter, $sort: [ModelSort!], $page: Page) {
  models(filter: $filter, sort: $sort, page: $page) {
    result {
      id
      name
    }
    errors
    count
  }
}
```