### PR TITLE
Add null check for single resolver

### DIFF
--- a/src/magql/resolver_factory.py
+++ b/src/magql/resolver_factory.py
@@ -529,6 +529,9 @@ class SingleResolver(QueryResolver):
     the instance specified by id.
     """
 
+    def post_resolve(self, resolved_value, parent, info, *args, **kwargs):
+        return resolved_value if resolved_value else {"result": resolved_value}
+
     def retrieve_value(self, parent, info, *args, **kwargs):
         """
         Retrieves the row in the table that matches the id in the args,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,52 @@ def status():
 
 
 @pytest.fixture
+def single_query():
+    return """
+query test {
+  person(id: 1) {
+    result {
+      name
+    }
+  }
+  car(id: 2) {
+    result {
+      name
+    }
+  }
+  house(id: 3) {
+    result {
+      name
+    }
+  }
+}
+"""
+
+
+@pytest.fixture
+def many_query():
+    return """
+query test {
+  people {
+    result {
+      name
+    }
+  }
+  cars {
+    result {
+      name
+    }
+  }
+  houses {
+    result {
+      name
+    }
+  }
+}
+"""
+
+
+@pytest.fixture
 def session(car, house, person):
     """Create and configure a new app instance for each test."""
     # create the app with common test config

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -98,4 +98,7 @@ def test_single_resolvers(model, model_id, session, info):
     resolver = SingleResolver(model.__table__)
     resolved_value = resolver(None, info, id=model_id)
     queried_value = session.query(model).filter_by(id=model_id).one_or_none()
-    assert queried_value == resolved_value
+    if queried_value is not None:
+        assert queried_value == resolved_value
+    else:
+        assert resolved_value["result"] is None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,25 +5,6 @@ from graphql import parse
 from .conftest import Car
 from magql.convert import Convert
 
-query = """
-query test {
-  people {
-    result {
-      name
-    }
-  }
-  cars {
-    result {
-      name
-    }
-  }
-  houses {
-    result {
-      name
-    }
-  }
-}
-"""
 
 query_pagination = """
 query test($page: Page) {
@@ -47,8 +28,16 @@ def schema(manager_collection):
     return Convert(manager_list).generate_schema()
 
 
-def test_schema(session, schema):
-    document = parse(query)
+def test_single_query(session, schema, single_query):
+    document = parse(single_query)
+    result = execute(schema, document, context_value=session)
+    assert result.data["person"]["result"]["name"] == "Person 1"
+    assert result.data["car"]["result"]["name"] is None
+    assert result.data["house"]["result"]["name"] is None
+
+
+def test_many_query(session, schema, many_query):
+    document = parse(many_query)
     result = execute(schema, document, context_value=session)
     assert result.data["people"]["result"][0]["name"] == "Person 1"
     assert result.data["cars"]["result"][0]["name"] == "Car 1"


### PR DESCRIPTION
When a single query is run with an id that is not in the database a GraphQL error occurs due to a non-nullable field returning None. Due to the way the GraphQL type checking happens, the single_resolver cannot return None. The solution proposed here is to simply return the result dictionary with the None value instead of the None value directly. The other option would be to return an error indicating that no row was found.