### PR TITLE
Add exists and does not exist string filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ v0.5.0
 
 Unreleased
 
+-   Added EXISTS and DOESNOTEXIST string operators for filtering
+
 v0.4.1
 ------
 

--- a/src/magql/filter.py
+++ b/src/magql/filter.py
@@ -171,10 +171,6 @@ def _get_date_comparator(_):
     return condition
 
 
-def props(cls):
-    return [i for i in cls.__dict__.keys() if i[:1] != "_"]
-
-
 @get_filter_comparator.register(JSONType)
 @get_filter_comparator.register(Text)
 @get_filter_comparator.register(UnicodeText)

--- a/src/magql/filter.py
+++ b/src/magql/filter.py
@@ -30,7 +30,13 @@ StringFilter = MagqlInputObjectType(
     {
         "operator": MagqlInputField(
             MagqlEnumType(
-                "StringOperator", {"INCLUDES": "INCLUDES", "EQUALS": "EQUALS", "EXISTS": "EXISTS", "DOESNOTEXIST": "DOESNOTEXIST"}
+                "StringOperator",
+                {
+                    "INCLUDES": "INCLUDES",
+                    "EQUALS": "EQUALS",
+                    "EXISTS": "EXISTS",
+                    "DOESNOTEXIST": "DOESNOTEXIST",
+                },
             )
         ),
         "value": MagqlInputField("String"),
@@ -182,9 +188,9 @@ def _get_string_comparator(_):
         elif filter_operator == "EQUALS":
             return field == filter_value
         elif filter_operator == "EXISTS":
-            return field != None
+            return field is not None
         elif filter_operator == "DOESNOTEXIST":
-            return field == None
+            return field is None
 
     return condition
 

--- a/src/magql/filter.py
+++ b/src/magql/filter.py
@@ -171,6 +171,10 @@ def _get_date_comparator(_):
     return condition
 
 
+def props(cls):
+    return [i for i in cls.__dict__.keys() if i[:1] != "_"]
+
+
 @get_filter_comparator.register(JSONType)
 @get_filter_comparator.register(Text)
 @get_filter_comparator.register(UnicodeText)
@@ -188,9 +192,9 @@ def _get_string_comparator(_):
         elif filter_operator == "EQUALS":
             return field == filter_value
         elif filter_operator == "EXISTS":
-            return field is not None
+            return field.like("%")
         elif filter_operator == "DOESNOTEXIST":
-            return field is None
+            return field == None  # noqa: E711
 
     return condition
 

--- a/src/magql/filter.py
+++ b/src/magql/filter.py
@@ -30,7 +30,7 @@ StringFilter = MagqlInputObjectType(
     {
         "operator": MagqlInputField(
             MagqlEnumType(
-                "StringOperator", {"INCLUDES": "INCLUDES", "EQUALS": "EQUALS"}
+                "StringOperator", {"INCLUDES": "INCLUDES", "EQUALS": "EQUALS", "EXISTS": "EXISTS", "DOESNOTEXIST": "DOESNOTEXIST"}
             )
         ),
         "value": MagqlInputField("String"),
@@ -181,6 +181,10 @@ def _get_string_comparator(_):
             return field.like(f"%{filter_value}%")
         elif filter_operator == "EQUALS":
             return field == filter_value
+        elif filter_operator == "EXISTS":
+            return field != None
+        elif filter_operator == "DOESNOTEXIST":
+            return field == None
 
     return condition
 

--- a/src/magql/filter.py
+++ b/src/magql/filter.py
@@ -190,7 +190,7 @@ def _get_string_comparator(_):
         elif filter_operator == "EXISTS":
             return field.like("%")
         elif filter_operator == "DOESNOTEXIST":
-            return field == None  # noqa: E711
+            return field.is_(None)
 
     return condition
 


### PR DESCRIPTION
On line 193 below I am unable to get around using the equality operator with the None type.
It directly translates to `Model.field IS NULL` on the front end, which is what I need.
`field is None` is simply translated to `False` on the front end. I tried every other way I could think of and can not get the same results as with` field == None`.
I have it currently marked as a Flake8 exception. 