### PR TITLE
name references can use non-null and list marks

### DIFF
--- a/src/magql/schema.py
+++ b/src/magql/schema.py
@@ -92,6 +92,15 @@ class Schema:
             seen.add(node)
 
             if isinstance(node, str):
+                # Remove non-null ! and list [] marks, handled by _apply_types below.
+                while True:
+                    if node[-1] == "!":
+                        node = node[:-1]
+                    elif node[0] == "[":
+                        node = node[1:-1]
+                    else:
+                        break
+
                 if node not in type_map:
                     # Record a type name with no definition.
                     type_map[node] = None


### PR DESCRIPTION
Allows writing `"[String!]!"` instead of `NonNull("String").list.non_null` or `String.non_null.list.non_null`. When collecting types, the markup is stripped, then when applying types the markup is stripped again and replaced with wrappers. This could be more efficient by moving the strip+wrap code to `__init__` instead, but it was more straightforward to use the existing type handling code.