### PR TITLE
test complex validation scenarios

### DIFF
--- a/src/magql/testing.py
+++ b/src/magql/testing.py
@@ -35,15 +35,11 @@ def expect_data(schema: Schema, source: str, **kwargs: t.Any) -> dict[str, t.Any
 
 def expect_errors(schema: Schema, source: str, **kwargs: t.Any) -> list[GraphQLError]:
     """Call :meth:`.Schema.execute` and return the errors portion of the result.
-    Raise an error if there is any data in the result, or if there are no errors.
+    Raise an error if there are no errors.
 
     .. versionadded:: 1.1
     """
     result = schema.execute(source=source, **kwargs)
-
-    if result.data is not None:
-        raise ValueError("Expected query to return an error, but it returned data.")
-
     assert result.errors is not None
     return result.errors
 

--- a/tests/test_validation/test_complex_validation.py
+++ b/tests/test_validation/test_complex_validation.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+
+import graphql
+
+import magql
+from magql.testing import expect_data
+from magql.testing import expect_validation_error
+
+
+@dataclass
+class Depth:
+    stringValue: list[list[list[list[str]]]] | None
+    intValue: list[list[int]] | None
+
+
+# stringValue Validators (InputField)
+def validate_first_list_length(
+    info: graphql.GraphQLResolveInfo, value: t.Any, data: dict[str, t.Any]
+) -> None:
+    if len(value) != 2:
+        raise magql.ValidationError("Outer list must have at exactly 2 items.")
+
+
+def validate_second_list_length(
+    info: graphql.GraphQLResolveInfo, value: t.Any, data: dict[str, t.Any]
+) -> None:
+    if len(value) != 3:
+        raise magql.ValidationError("Middle list must have at exactly 3 items.")
+
+
+def validate_third_list_length(
+    info: graphql.GraphQLResolveInfo, value: t.Any, data: dict[str, t.Any]
+) -> None:
+    if len(value) != 4:
+        raise magql.ValidationError("Inner list must have at exactly 4 items.")
+
+
+def validate_contains_special_character(
+    info: graphql.GraphQLResolveInfo, value: str, data: dict[str, t.Any]
+) -> None:
+    special_characters = "!#$%&'()*+,-./:;<=>?@[]^_`{|}~"
+    if not any(char in special_characters for char in value):
+        raise magql.ValidationError("Must contain a special character.")
+
+
+# intValue Validators (InputField)
+def validate_integer_properties(
+    info: graphql.GraphQLResolveInfo, value: t.Any, data: dict[str, t.Any]
+) -> None:
+    errors = [
+        message
+        for condition, message in [
+            (value % 2 != 0, "Must be even."),
+            (value < 0, "Must be positive."),
+        ]
+        if condition
+    ]
+    if errors:
+        raise magql.ValidationError([errors])
+
+
+# DepthInput Validators (InputObject)
+def validate_user_input(
+    info: graphql.GraphQLResolveInfo, data: dict[str, t.Any]
+) -> None:
+    stringValue = data.get("stringValue")
+    intValue = data.get("intValue")
+    if stringValue and intValue and len(intValue) < len(stringValue):
+        raise magql.ValidationError(
+            "Length of intValue should not be shorter than the length of stringValue."
+        )
+
+
+DepthInput = magql.InputObject(
+    "DepthInput",
+    fields={
+        "stringValue": magql.InputField(
+            "[[[String!]]]!",
+            validators=[
+                validate_first_list_length,
+                [
+                    validate_second_list_length,
+                    [validate_third_list_length, [validate_contains_special_character]],
+                ],  # type: ignore[list-item]
+            ],
+        ),
+        "intValue": magql.InputField(
+            "[[Int!]]",
+            validators=[[[validate_integer_properties]]],  # type: ignore[list-item]
+        ),
+    },
+    validators=[validate_user_input],
+)
+
+schema = magql.Schema(
+    types=[
+        magql.Object(
+            "Depth",
+            fields={
+                "stringValue": "[[[String!]]]",
+                "intValue": "[[Int!]]",
+            },
+        ),
+        DepthInput,
+    ]
+)
+
+
+@schema.query.field("depth", "Depth!", args={"input": magql.Argument("DepthInput!")})
+def resolve_depth(
+    parent: t.Any, info: graphql.GraphQLResolveInfo, **kwargs: t.Any
+) -> Depth:
+    input = kwargs["input"]
+    return Depth(
+        stringValue=input.get("stringValue"),
+        intValue=input.get("intValue"),
+    )
+
+
+valid_op = """\
+query($i: DepthInput!) {
+  depth(input: $i) {
+    stringValue
+    intValue
+  }
+}
+"""
+
+
+def test_valid_input() -> None:
+    """Valid input does not have errors."""
+    variables = {
+        "i": {
+            "stringValue": [
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+            ],
+            "intValue": [[2, 4], [98, 2, 44], [4]],
+        }
+    }
+    result = expect_data(schema, valid_op, variables=variables)
+    assert result == {
+        "depth": {
+            "stringValue": [
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+            ],
+            "intValue": [[2, 4], [98, 2, 44], [4]],
+        }
+    }
+
+
+def test_invalid_items() -> None:
+    """Test case for validating the contents of nested lists in the query.
+    'stringValue': some strings do not contain special chars
+    'intValue': some integers are negative | odd
+    Also verifies the capability of the validation logic to
+    return multiple error messages for a single item when necessary.
+    """
+    variables = {
+        "i": {
+            "stringValue": [
+                [
+                    ["noSpecial", "#special", "!special", "noSpecial"],
+                    ["!special", "noSpecial", "!special", "#special"],
+                    ["!special", "#special", "noSpecial", "#special"],
+                ],
+                [
+                    ["!special", "noSpecial", "!special", "#special"],
+                    ["!special", "#special", "noSpecial", "noSpecial"],
+                    ["noSpecial", "#special", "!special", "#special"],
+                ],
+            ],
+            "intValue": [[2, 4, -4], [1, 2], [-43, -4, 3]],
+        }
+    }
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0]["stringValue"][0] == [
+        [
+            [
+                "Must contain a special character.",
+                None,
+                None,
+                "Must contain a special character.",
+            ],
+            [None, "Must contain a special character.", None, None],
+            [None, None, "Must contain a special character.", None],
+        ],
+        [
+            [None, "Must contain a special character.", None, None],
+            [
+                None,
+                None,
+                "Must contain a special character.",
+                "Must contain a special character.",
+            ],
+            ["Must contain a special character.", None, None, None],
+        ],
+    ]
+    assert result["input"][0]["intValue"][0] == [
+        [None, None, ["Must be positive."]],
+        [["Must be even."], None],
+        [
+            ["Must be even.", "Must be positive."],
+            ["Must be positive."],
+            ["Must be even."],
+        ],
+    ]
+
+
+def test_invalid_nested_lists() -> None:
+    """Test case for validating the structure of nested lists in the query.
+    'stringValue': Lists do not adhere to required length specifications.
+    Validates the incorrect list lengths at each nesting level.
+    """
+    variables = {
+        "i": {
+            "stringValue": [
+                [
+                    ["!special", "#special"],
+                    ["!special", "#special", "!special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special"],
+                ],
+                [
+                    ["!special", "#special", "!special"],
+                    ["!special", "#special", "!special"],
+                ],
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+            ],
+        }
+    }
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0]["stringValue"] == [
+        "Outer list must have at exactly 2 items.",
+        [
+            "Middle list must have at exactly 3 items.",
+            [
+                "Inner list must have at exactly 4 items.",
+                "Inner list must have at exactly 4 items.",
+                None,
+                "Inner list must have at exactly 4 items.",
+            ],
+            "Middle list must have at exactly 3 items.",
+            [
+                "Inner list must have at exactly 4 items.",
+                "Inner list must have at exactly 4 items.",
+            ],
+            None,
+        ],
+    ]
+
+
+def test_invalid_object() -> None:
+    """Test case for validating the structure of the overall input object.
+    'intValue': Its length is shorter than 'stringValue'.
+    Asserts ability to validate a collection of inputs.
+    """
+    variables = {
+        "i": {
+            "stringValue": [
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+                [
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                    ["!special", "#special", "!special", "#special"],
+                ],
+            ],
+            "intValue": [[2, 4]],
+        }
+    }
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert (
+        result["input"][0][""][0]
+        == "Length of intValue should not be shorter than the length of stringValue."
+    )
+
+
+def test_invalid_combined() -> None:
+    """Comprehensive test case that combines all possible invalid inputs.
+    Validates the ability to handle multiple types of input errors simultaneously.
+    """
+    variables = {
+        "i": {
+            "stringValue": [
+                [
+                    ["noSpecial", "noSpecial"],
+                    ["!special", "noSpecial", "!special"],
+                    ["!special", "noSpecial", "!special", "#special"],
+                    ["!special"],
+                ],
+                [
+                    ["!special", "noSpecial", "!special"],
+                    ["!special", "noSpecial", "!special"],
+                ],
+                [
+                    ["!special", "!Special", "nospecial", "#special"],
+                    ["!special", "noSpecial", "!special", "#special"],
+                    ["nospecial", "!Special", "!special", "#special"],
+                ],
+            ],
+            "intValue": [[1, -4, 2], [2, -3]],
+        }
+    }
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0]["stringValue"] == [
+        "Outer list must have at exactly 2 items.",
+        [
+            "Middle list must have at exactly 3 items.",
+            [
+                "Inner list must have at exactly 4 items.",
+                [
+                    "Must contain a special character.",
+                    "Must contain a special character.",
+                ],
+                "Inner list must have at exactly 4 items.",
+                [None, "Must contain a special character.", None],
+                [None, "Must contain a special character.", None, None],
+                "Inner list must have at exactly 4 items.",
+            ],
+            "Middle list must have at exactly 3 items.",
+            [
+                "Inner list must have at exactly 4 items.",
+                [None, "Must contain a special character.", None],
+                "Inner list must have at exactly 4 items.",
+                [None, "Must contain a special character.", None],
+            ],
+            [
+                [None, None, "Must contain a special character.", None],
+                [None, "Must contain a special character.", None, None],
+                ["Must contain a special character.", None, None, None],
+            ],
+        ],
+    ]
+    assert result["input"][0]["intValue"][0] == [
+        [["Must be even."], ["Must be positive."], None],
+        [None, ["Must be even.", "Must be positive."]],
+    ]
+    assert (
+        result["input"][0][""][0]
+        == "Length of intValue should not be shorter than the length of stringValue."
+    )

--- a/tests/test_validation/test_field_validation.py
+++ b/tests/test_validation/test_field_validation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+
+import graphql
+
+import magql.validators
+from magql.testing import expect_data
+from magql.testing import expect_validation_error
+
+
+@dataclass
+class User:
+    username: str
+    profession: str | None
+    hobbies: list[str] | None
+
+
+def validate_profession_given_if_hobbies(
+    info: graphql.GraphQLResolveInfo, data: dict[str, t.Any]
+) -> None:
+    hobbies = data.get("hobbies")
+    profession = data.get("profession")
+    if hobbies is not None and len(hobbies) < 3 and profession is not None:
+        raise magql.ValidationError(
+            "Profession cannot be provided "
+            "if the user does not have more than 2 hobbies."
+        )
+
+
+def validate_profession_starts_with_username(
+    info: graphql.GraphQLResolveInfo, data: dict[str, t.Any]
+) -> None:
+    username = data.get("username")
+    profession = data.get("profession")
+    if profession is not None and not profession.startswith(f"{username}_"):
+        raise magql.ValidationError(
+            "Profession must start with username followed by '_'."
+        )
+
+
+schema = magql.Schema(
+    types=[
+        magql.Object(
+            "User",
+            fields={
+                "username": "String!",
+                "hobbies": "[String!]",
+                "profession": "String",
+            },
+        )
+    ]
+)
+
+
+@schema.query.field(
+    "user",
+    "User!",
+    args={
+        "username": magql.Argument("String!"),
+        "profession": magql.Argument("String"),
+        "hobbies": magql.Argument("[String!]"),
+    },
+    validators=[
+        validate_profession_given_if_hobbies,
+        validate_profession_starts_with_username,
+    ],
+)
+def resolve_user_create(
+    parent: t.Any, info: graphql.GraphQLResolveInfo, **kwargs: t.Any
+) -> User:
+    return User(
+        username=kwargs["username"],
+        profession=kwargs.get("profession"),
+        hobbies=kwargs.get("hobbies"),
+    )
+
+
+valid_op = """\
+query($u: String!, $h: [String!], $p: String) {
+  user(username: $u, hobbies: $h, profession: $p) {
+    username
+    hobbies
+    profession
+  }
+}
+"""
+
+
+def test_valid_user() -> None:
+    """Valid input does not have errors."""
+    variables = {"u": "K", "h": ["reading", "swimming", "coding"], "p": "K_programmer"}
+    result = expect_data(schema, valid_op, variables=variables)
+    assert result == {
+        "user": {
+            "username": "K",
+            "hobbies": ["reading", "swimming", "coding"],
+            "profession": "K_programmer",
+        }
+    }
+
+
+def test_invalid_profession_given_hobbies() -> None:
+    """Invalid input when profession is provided but hobbies length is less than 3."""
+    variables = {"u": "K", "h": ["reading", "swimming"], "p": "K_programmer"}
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result[""][0].startswith("Profession cannot be")
+
+
+def test_invalid_profession_starts_with_username() -> None:
+    """Invalid input when profession does not start with username."""
+    variables = {"u": "K", "h": ["reading", "swimming", "coding"], "p": "programmer_K"}
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result[""][0].startswith("Profession must start with")
+
+
+def test_invalid_multiple_errors() -> None:
+    """Invalid input when profession violates two validations"""
+    variables = {"u": "K", "h": ["Reading"], "p": "Doctor"}
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result[""][0].startswith("Profession cannot be")
+    assert result[""][1].startswith("Profession must start with")

--- a/tests/test_validation/test_inputfield_validation.py
+++ b/tests/test_validation/test_inputfield_validation.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+
+import graphql
+
+import magql.validators
+from magql.testing import expect_data
+from magql.testing import expect_validation_error
+
+
+@dataclass
+class User:
+    username: str
+    hobbies: list[str] | None
+
+
+def validate_lowercase(
+    info: graphql.GraphQLResolveInfo, value: str, data: dict[str, t.Any]
+) -> None:
+    if not value.islower():
+        raise magql.ValidationError("Must be lowercase.")
+
+
+def validate_specific_user_input(
+    info: graphql.GraphQLResolveInfo, value: dict[str, t.Any], data: dict[str, t.Any]
+) -> None:
+    if value == {"username": "A", "hobbies": ["a", "b", "C"]}:
+        raise magql.ValidationError("Specific UserInput is not allowed.")
+
+
+UserInput = magql.InputObject(
+    "UserInput",
+    fields={
+        "username": magql.InputField(
+            "String!",
+            validators=[validate_lowercase, magql.validators.Length(min=2, max=10)],
+        ),
+        "hobbies": magql.InputField(
+            "[String!]",
+            validators=[
+                magql.validators.Length(min=2),
+                [validate_lowercase],  # type: ignore[list-item]
+            ],
+        ),
+    },
+)
+
+NestedUserInput = magql.InputObject(
+    "NestedUserInput",
+    fields={
+        "user": magql.InputField(
+            "UserInput!", validators=[validate_specific_user_input]
+        )
+    },
+)
+
+schema = magql.Schema(
+    types=[
+        magql.Object("User", fields={"username": "String!", "hobbies": "[String!]"}),
+        UserInput,
+        NestedUserInput,
+    ]
+)
+
+
+@schema.query.field("user", "User!", args={"input": magql.Argument("UserInput!")})
+def resolve_user_create(
+    parent: t.Any, info: graphql.GraphQLResolveInfo, **kwargs: t.Any
+) -> User:
+    input = kwargs["input"]
+    return User(username=input["username"], hobbies=input.get("hobbies"))
+
+
+@schema.query.field(
+    "nestedUser", "User!", args={"input": magql.Argument("NestedUserInput!")}
+)
+def resolve_nested_user_create(
+    parent: t.Any, info: graphql.GraphQLResolveInfo, **kwargs: t.Any
+) -> User:
+    input = kwargs["input"]["user"]
+    return User(username=input["username"], hobbies=input.get("hobbies"))
+
+
+valid_op = """\
+query($i: UserInput!) {
+  user(input: $i) {
+    username
+    hobbies
+  }
+}
+"""
+
+nested_valid_op = """\
+query($i: NestedUserInput!) {
+  nestedUser(input: $i) {
+    username
+    hobbies
+  }
+}
+"""
+
+
+def test_valid() -> None:
+    """Valid input does not have errors."""
+    variables = {"i": {"username": "valid", "hobbies": ["read", "swim"]}}
+    result = expect_data(schema, valid_op, variables=variables)
+    assert result == {"user": {"username": "valid", "hobbies": ["read", "swim"]}}
+
+
+def test_invalid() -> None:
+    """Multiple fields can be invalid, and each field can have have multiple errors."""
+    result = expect_validation_error(
+        schema, valid_op, variables={"i": {"username": "A", "hobbies": []}}
+    )
+    assert result["input"][0]["username"][0] == "Must be lowercase."
+    assert result["input"][0]["username"][1].startswith("Length must be between")
+    assert result["input"][0]["hobbies"][0].startswith("Length must be at least")
+
+
+def test_list_validate_item() -> None:
+    """Validators can apply to list value or individual items."""
+    variables = {"i": {"username": "aa", "hobbies": ["A"]}}
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0]["hobbies"][0].startswith("Length must be at least")
+    assert result["input"][0]["hobbies"][1] == ["Must be lowercase."]
+
+
+def test_list_mixed_valid() -> None:
+    """Valid list values have None placeholder in errors."""
+    variables = {"i": {"username": "aa", "hobbies": ["a", "B"]}}
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0]["hobbies"][0] == [None, "Must be lowercase."]
+
+
+def test_nested_valid() -> None:
+    """Nested valid input does not have errors."""
+    variables = {"i": {"user": {"username": "valid", "hobbies": ["read", "swim"]}}}
+    result = expect_data(schema, nested_valid_op, variables=variables)
+    assert result == {"nestedUser": {"username": "valid", "hobbies": ["read", "swim"]}}
+
+
+def test_nested_invalid() -> None:
+    """Nested input objects are correctly validated."""
+    variables = {"i": {"user": {"username": "A", "hobbies": ["a", "b", "C"]}}}
+    result = expect_validation_error(schema, nested_valid_op, variables=variables)
+    arg = result["input"][0]
+    assert arg["user"][0]["username"][0] == "Must be lowercase."
+    assert arg["user"][0]["username"][1].startswith("Length must be between")
+    assert arg["user"][0]["hobbies"][0] == [None, None, "Must be lowercase."]
+    assert arg["user"][1] == "Specific UserInput is not allowed."

--- a/tests/test_validation/test_inputobject_validation.py
+++ b/tests/test_validation/test_inputobject_validation.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+
+import graphql
+
+import magql
+from magql.testing import expect_data
+from magql.testing import expect_validation_error
+
+
+@dataclass
+class User:
+    username: str
+    profession: str | None
+    hobbies: list[str] | None
+
+
+def validate_profession_given_if_hobbies(
+    info: graphql.GraphQLResolveInfo, data: dict[str, t.Any]
+) -> None:
+    hobbies = data.get("hobbies")
+    profession = data.get("profession")
+    if hobbies is not None and len(hobbies) < 3 and profession is not None:
+        raise magql.ValidationError(
+            "Profession cannot be provided "
+            "if the user does not have more than 2 hobbies."
+        )
+
+
+def validate_profession_starts_with_username(
+    info: graphql.GraphQLResolveInfo, data: dict[str, t.Any]
+) -> None:
+    username = data.get("username")
+    profession = data.get("profession")
+    if profession is not None and not profession.startswith(f"{username}_"):
+        raise magql.ValidationError(
+            "Profession must start with username followed by '_'."
+        )
+
+
+UserInput = magql.InputObject(
+    "UserInput",
+    fields={
+        "username": magql.InputField("String!"),
+        "profession": magql.InputField("String"),
+        "hobbies": magql.InputField("[String]"),
+    },
+    validators=[
+        validate_profession_given_if_hobbies,
+        validate_profession_starts_with_username,
+    ],
+)
+
+schema = magql.Schema(
+    types=[
+        magql.Object(
+            "User",
+            fields={
+                "username": "String!",
+                "profession": "String",
+                "hobbies": "[String]",
+            },
+        ),
+        UserInput,
+    ]
+)
+
+
+@schema.query.field("user", "User!", args={"input": magql.Argument("UserInput!")})
+def resolve_user_create(
+    parent: t.Any, info: graphql.GraphQLResolveInfo, **kwargs: t.Any
+) -> User:
+    input = kwargs["input"]
+    return User(
+        username=input["username"],
+        profession=input.get("profession"),
+        hobbies=input.get("hobbies"),
+    )
+
+
+valid_op = """\
+query($i: UserInput!) {
+  user(input: $i) {
+    username
+    profession
+    hobbies
+  }
+}
+"""
+
+
+def test_valid() -> None:
+    """Valid input does not have errors."""
+    variables = {
+        "i": {
+            "username": "K",
+            "profession": "K_Programmer",
+            "hobbies": ["Reading", "Swimming", "Coding"],
+        }
+    }
+    result = expect_data(schema, valid_op, variables=variables)
+    assert result == {
+        "user": {
+            "username": "K",
+            "profession": "K_Programmer",
+            "hobbies": ["Reading", "Swimming", "Coding"],
+        }
+    }
+
+
+def test_invalid_profession_given_hobbies() -> None:
+    """Invalid input when profession is provided but hobbies length is less than 3."""
+    variables = {
+        "i": {"username": "K", "profession": "K_Programmer", "hobbies": ["Reading"]}
+    }
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0][""][0].startswith("Profession cannot be")
+
+
+def test_invalid_profession_name() -> None:
+    """Invalid input when profession does not start with username."""
+    variables = {
+        "i": {
+            "username": "K",
+            "profession": "Programmer",
+            "hobbies": ["Reading", "Swimming", "Coding"],
+        }
+    }
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0][""][0].startswith("Profession must start with")
+
+
+def test_invalid_multiple_errors() -> None:
+    """Invalid input when profession violates two validations"""
+    variables = {"i": {"username": "K", "profession": "Doctor", "hobbies": ["Reading"]}}
+    result = expect_validation_error(schema, valid_op, variables=variables)
+    assert result["input"][0][""][0].startswith("Profession cannot be")
+    assert result["input"][0][""][1].startswith("Profession must start with")

--- a/tests/test_validation/test_validators.py
+++ b/tests/test_validation/test_validators.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+
+import graphql
+import pytest
+
+import magql.validators
+from magql.testing import expect_data
+from magql.testing import expect_validation_error
+
+
+@dataclass
+class User:
+    username: str
+    password: str
+    password_confirm: str
+    email: str
+    grade: str
+    height: float
+    weight: int
+    age: int
+    experience: int
+
+
+UserType = magql.Object(
+    "User",
+    fields={
+        "username": "String!",
+        "password": "String!",
+        "password_confirm": "String!",
+        "email": "String!",
+        "grade": "String!",
+        "height": "Float!",
+        "weight": "Int!",
+        "age": "Int!",
+        "experience": "Int!",
+    },
+)
+
+schema = magql.Schema(types=[UserType])
+
+
+@schema.query.field(
+    "user",
+    UserType,
+    args={
+        "username": magql.Argument(
+            "String!",
+            validators=[
+                magql.validators.Length(min=2, max=10),
+            ],
+        ),
+        "password": magql.Argument(
+            "String!",
+            validators=[magql.validators.Length(min=8)],
+        ),
+        "password_confirm": magql.Argument(
+            "String!",
+            validators=[magql.validators.Confirm("password")],
+        ),
+        "email": magql.Argument(
+            "String!",
+            validators=[magql.validators.Length(max=50)],
+        ),
+        "grade": magql.Argument(
+            "String!",
+            validators=[magql.validators.Length(min=1, max=1)],
+        ),
+        "height": magql.Argument(
+            "Float!",
+            validators=[magql.validators.NumberRange(min=0.0, max=2.5)],
+        ),
+        "weight": magql.Argument(
+            "Int!",
+            validators=[magql.validators.NumberRange(max=200)],
+        ),
+        "age": magql.Argument(
+            "Int!",
+            validators=[magql.validators.NumberRange(min=0)],
+        ),
+        "experience": magql.Argument(
+            "Int!",
+            validators=[magql.validators.NumberRange(min=5, max=5)],
+        ),
+    },
+)
+def resolve_user_create(
+    parent: t.Any, info: graphql.GraphQLResolveInfo, **kwargs: t.Any
+) -> User:
+    return User(
+        username=kwargs["username"],
+        password=kwargs["password"],
+        password_confirm=kwargs["password_confirm"],
+        email=kwargs["email"],
+        grade=kwargs["grade"],
+        height=kwargs["height"],
+        weight=kwargs["weight"],
+        age=kwargs["age"],
+        experience=kwargs["experience"],
+    )
+
+
+valid_op = """\
+query(
+  $u: String!,
+  $p: String!,
+  $pc: String!,
+  $e: String!,
+  $g: String!,
+  $h: Float!,
+  $w: Int!,
+  $a: Int!,
+  $ex: Int!
+) {
+  user(
+    username: $u,
+    password: $p,
+    password_confirm: $pc,
+    email: $e,
+    grade: $g,
+    height: $h,
+    weight: $w,
+    age: $a,
+    experience: $ex
+  ) {
+    username
+    password
+    password_confirm
+    email
+    grade
+    height
+    weight
+    age
+    experience
+  }
+}
+"""
+
+
+@pytest.fixture
+def user_data() -> dict[str, t.Any]:
+    return {
+        "u": "validuser",
+        "p": "validpass",
+        "pc": "validpass",
+        "e": "validemail@example.com",
+        "g": "A",
+        "h": 1.75,
+        "w": 70,
+        "a": 25,
+        "ex": 5,
+    }
+
+
+def test_valid_user(user_data: dict[str, t.Any]) -> None:
+    """Valid input does not have errors."""
+    result = expect_data(schema, valid_op, variables=user_data)
+    assert result["user"] == {
+        "username": user_data["u"],
+        "password": user_data["p"],
+        "password_confirm": user_data["pc"],
+        "email": user_data["e"],
+        "grade": user_data["g"],
+        "height": user_data["h"],
+        "weight": user_data["w"],
+        "age": user_data["a"],
+        "experience": user_data["ex"],
+    }
+
+
+@pytest.mark.parametrize(
+    "field, variable, value, error_msg",
+    [
+        ("username", "u", "a", "Length must be between 2 and 10, but was 1."),
+        ("password", "p", "pass", "Length must be at least 8, but was 4."),
+        (
+            "password_confirm",
+            "pc",
+            "invalidpass",
+            "Must equal the value given in 'password'.",
+        ),
+        (
+            "email",
+            "e",
+            "a" * 51 + "@example.com",
+            "Length must be at most 50, but was 63.",
+        ),
+        ("grade", "g", "AB", "Length must be exactly 1, but was 2."),
+        ("height", "h", 3.0, "Must be between 0.0 and 2.5."),
+        ("weight", "w", 201, "Must be at most 200."),
+        ("age", "a", -1, "Must be at least 0."),
+        ("experience", "ex", 4, "Must be between 5 and 5."),
+    ],
+    ids=[
+        "invalid_username_length",
+        "invalid_password_length",
+        "invalid_password_confirm",
+        "invalid_email_length",
+        "invalid_grade_length",
+        "invalid_height_range",
+        "invalid_weight_range",
+        "invalid_age_range",
+        "invalid_experience_range",
+    ],
+)
+def test_invalid_fields(
+    user_data: dict[str, t.Any], field: str, variable: str, value: t.Any, error_msg: str
+) -> None:
+    """Test various invalid input cases for each field in the User GraphQL type.
+
+    For each parameter set, the function executes a GraphQL query using the
+    provided invalid value for the specified field. It then verifies that the
+    error message returned by the GraphQL execution matches the expected error
+    message.
+
+    The purpose of this function is to ensure that the validation rules for
+    each field in the User GraphQL type are correctly enforced.
+
+    :param field: The name of the field in the User GraphQL type to test.
+    :param variable: The corresponding variable name in the GraphQL query.
+    :param value: The invalid input value to use for testing.
+    :param error_msg: The expected error message when the invalid input is used.
+    """
+    user_data[variable] = value
+    result = expect_validation_error(schema, valid_op, variables=user_data)
+    assert result[field][0] == error_msg


### PR DESCRIPTION
* test_inputfield_validation.py
  * test_valid
  * test_invalid
  * test_list_validate_item
  * test_list_mixed_valid
    * actually kept this since the operated input will be different than the one for argument level
  * test_nested_invalid
    * tested input field of input field (nested)
    
* test_inputobject_validation.py
  * tested validation on a simple relationship between "profession" and "hobbies"
  * test_valid_user
  * test_no_profession_provided
  * test_invalid_profession_given_hobbies
  * test_invalid_profession_name
  * test_invalid_multiple_errors
  
  Added in static type check assertions for test cases along with `# type: ignore[list-item]` for the list validator.