### PR TITLE
Fix descriptions in 0.7.0

### DIFF
--- a/src/magql/convert.py
+++ b/src/magql/convert.py
@@ -97,11 +97,7 @@ class Convert:
                 )
 
             field.type_name = Convert.convert_type(field.type_name, magql_type_map)
-            if not isinstance(field, MagqlInputField):
-                for arg_name, arg in field.args.items():
-                    field.args[arg_name] = Convert.convert_type(
-                        arg.type_, magql_type_map
-                    )
+
         return None
 
     def generate_type_map(self, managers: t.List[MagqlManager]) -> None:

--- a/src/magql/definitions.py
+++ b/src/magql/definitions.py
@@ -80,10 +80,16 @@ class MagqlObjectType:
         self.description = description
 
     def field(
-        self, field_name: str, return_type: t.Any, args: t.Optional[t.Any] = None
+        self,
+        field_name: str,
+        return_type: t.Any,
+        args: t.Optional[t.Any] = None,
+        description: t.Optional[str] = None,
     ) -> t.Callable:
         def decorator(resolve: t.Callable) -> t.Callable:
-            self.fields[field_name] = MagqlField(return_type, args, resolve)
+            self.fields[field_name] = MagqlField(
+                return_type, args, resolve, description
+            )
             return resolve
 
         return decorator
@@ -141,7 +147,9 @@ class MagqlField:
             field_type = type_map[t.cast(str, self.type_name)]
         else:
             field_type = t.cast(t.Any, self.type_name).convert(type_map)
-        return GraphQLField(field_type, gql_args, self.resolve)
+        return GraphQLField(
+            field_type, gql_args, self.resolve, description=self.description
+        )
 
 
 def js_camelize(word: str) -> str:
@@ -151,9 +159,15 @@ def js_camelize(word: str) -> str:
 
 
 class MagqlArgument:  # noqa: E501
-    def __init__(self, type_: t.Any, default_value: t.Optional[t.Any] = None):
+    def __init__(
+        self,
+        type_: t.Any,
+        default_value: t.Optional[t.Any] = None,
+        description: t.Optional[str] = None,
+    ):
         self.type_ = type_
         self.default_value = default_value
+        self.description = description
 
     def convert(
         self,
@@ -184,6 +198,7 @@ class MagqlArgument:  # noqa: E501
                 converted_type,
             ),
             self.default_value,
+            self.description,  # not showing up in the schema.graphql file
         )
 
 
@@ -232,7 +247,8 @@ class MagqlInputField:
                     GraphQLWrappingType,
                 ],
                 field_type,
-            )
+            ),
+            description=self.description,
         )
 
 

--- a/src/magql/definitions.py
+++ b/src/magql/definitions.py
@@ -21,6 +21,7 @@ from graphql import GraphQLString
 from graphql import GraphQLType
 from graphql import GraphQLUnionType
 from graphql import GraphQLWrappingType
+from graphql import Undefined
 from graphql.type.scalars import coerce_float
 from graphql.type.scalars import coerce_int
 from inflection import camelize
@@ -162,7 +163,7 @@ class MagqlArgument:  # noqa: E501
     def __init__(
         self,
         type_: t.Any,
-        default_value: t.Optional[t.Any] = None,
+        default_value: t.Optional[t.Any] = Undefined,
         description: t.Optional[str] = None,
     ):
         self.type_ = type_
@@ -198,7 +199,7 @@ class MagqlArgument:  # noqa: E501
                 converted_type,
             ),
             self.default_value,
-            self.description,  # not showing up in the schema.graphql file
+            self.description,
         )
 
 


### PR DESCRIPTION
In Magql 0.7.0, several Magql objects either did not accept a description as a parameter, or did not pass the description along when converting into a GraphQL object. This PR resolves that for MagqlObjectType, MagqlArgument, MagqlField, and MagqlInputField.

Additionally, the convert function for MagqlArgument was never being invoked. Instead, the `convert_str_leafs` fn, which converts string representations of fields into their Magql counterpart, was also performing that on MagqlArguments. So all MagqlArguments were being converted without the help of `MagqlArgument.convert`. Without the MagqlArgument converter from being called, the description *and* the default_value were never being included in the schema. By removing the call to `Convert.convert_type` for MagqlArguments, `MagqlArgument.convert` is now being invoked for all MagqlArguments.