### PR TITLE
set description from docstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ Version 1.1.0
 
 Unreleased
 
+-   `@object.field` and `@field.resolver` decorators use the decorated
+    function's docstring as the description for the field if it's not otherwise
+    set. {issue}`112`
+
 
 Version 1.0.1
 -------------

--- a/examples/upload/upload.py
+++ b/examples/upload/upload.py
@@ -4,17 +4,23 @@ import typing as t
 from pathlib import Path
 
 import flask_magql
+from flask import Blueprint
+from flask import current_app
+from flask import Flask
+from flask import send_file
+from flask import url_for
+from flask_sqlalchemy_lite import SQLAlchemy
 from graphql import GraphQLResolveInfo
 from magql_sqlalchemy import ModelManager
-from magql_sqlalchemy.resolvers import CreateResolver, UpdateResolver
+from magql_sqlalchemy.resolvers import CreateResolver
+from magql_sqlalchemy.resolvers import UpdateResolver
 from sqlalchemy import orm
-from flask import Flask, url_for, current_app, Blueprint, send_file
-from flask_sqlalchemy_lite import SQLAlchemy
 from werkzeug import Response
 from werkzeug.datastructures import FileStorage
 
 import magql
-from magql import Field, Argument
+from magql import Argument
+from magql import Field
 
 db = SQLAlchemy()
 schema = magql.Schema()
@@ -64,7 +70,9 @@ default_document_update = UpdateResolver(Document)
 
 
 @document_manager.create_field.resolver
-def resolve_document_create(parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any) -> Document:
+def resolve_document_create(
+    parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any
+) -> Document:
     """Create the document in the database and save the file."""
     # Remove file from args, it will be handled separately.
     file: FileStorage = kwargs.pop("file")
@@ -77,7 +85,9 @@ def resolve_document_create(parent: t.Any, info: GraphQLResolveInfo, **kwargs: t
 
 
 @document_manager.update_field.resolver
-def resolve_document_update(parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any) -> Document:
+def resolve_document_update(
+    parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any
+) -> Document:
     """Update the document in the database, optional save a new file."""
     file: FileStorage | None = kwargs.pop("file", None)
     doc: Document = default_document_update(parent, info, **kwargs)

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import typing as t
+
+from graphql import GraphQLResolveInfo
+
+import magql
+
+
+def test_clean_description() -> None:
+    """Indentation and trailing space is removed from multiline string."""
+    field = magql.Field(
+        "String",
+        description="""A description
+
+        with multiple
+        lines.
+        """,
+    )
+    assert field.description == "A description\n\nwith multiple\nlines."
+
+
+def test_clean_description_to_graphql() -> None:
+    """Description is cleaned when converted to GraphQL."""
+    field = magql.Field(magql.String)
+    field.description = """A description
+
+    with multiple
+    lines.
+    """
+    desc = field._to_graphql().description
+    assert desc == "A description\n\nwith multiple\nlines."
+
+
+def test_field_docstring() -> None:
+    """Field decorator uses docstring as description."""
+    obj = magql.Object("User")
+
+    @obj.field("name", "String")
+    def resolve_user_name(
+        parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any
+    ) -> t.Any:
+        """first"""
+        pass
+
+    assert obj.fields["name"].description == "first"
+
+
+def test_field_no_docstring() -> None:
+    """Function without docstring is allowed."""
+    obj = magql.Object("User")
+
+    @obj.field("name", "String")
+    def resolve_user_name(
+        parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any
+    ) -> t.Any:
+        pass
+
+    assert obj.fields["name"].description is None
+
+
+def test_field_no_override() -> None:
+    obj = magql.Object("User")
+
+    @obj.field("name", "String", description="first")
+    def resolve_user_name(
+        parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any
+    ) -> t.Any:
+        """second"""
+        pass
+
+    assert obj.fields["name"].description == "first"
+
+
+def test_resolver_docstring() -> None:
+    """Resolver decorator uses docstring as description."""
+    field = magql.Field("String")
+
+    @field.resolver
+    def resolve(parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any) -> t.Any:
+        """first"""
+        pass
+
+    assert field.description == "first"
+
+
+def test_resolver_no_docstring() -> None:
+    """Function without docstring is allowed."""
+    field = magql.Field("String")
+
+    @field.resolver
+    def resolve(parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any) -> t.Any:
+        pass
+
+    assert field.description is None
+
+
+def test_resolver_no_override() -> None:
+    """Docstring is not used if description is set."""
+    field = magql.Field("String", description="first")
+
+    @field.resolver
+    def resolve(parent: t.Any, info: GraphQLResolveInfo, **kwargs: t.Any) -> t.Any:
+        """second"""
+        pass
+
+    assert field.description == "first"


### PR DESCRIPTION
Descriptions are set from docstrings of functions decorated with `@field` or `@resolver`. Descriptions and other messages are passed through `cleandoc` when being created and when creating the GraphQL object.

closes #112 