### PR TITLE
add testing helper functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
 -   `@object.field` and `@field.resolver` decorators use the decorated
     function's docstring as the description for the field if it's not otherwise
     set. {issue}`112`
+-   Added the `testing` module with functions to execute a query and expect
+    data, errors, a single error, or a validation error. {issue}`86`
 
 
 Version 1.0.1

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,3 +103,14 @@ This API is typically implemented and managed by a data source integration.
 .. currentmodule:: magql.filters
 .. autodata:: filter_item
 ```
+
+
+## Testing
+
+```{eval-rst}
+.. currentmodule:: magql.testing
+.. autofunction:: expect_data
+.. autofunction:: expect_errors
+.. autofunction:: expect_error
+.. autofunction:: expect_validation_error
+```

--- a/src/magql/testing.py
+++ b/src/magql/testing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import typing as t
+
+from graphql import GraphQLError
+
+from magql import Schema
+
+
+def expect_data(schema: Schema, source: str, **kwargs: t.Any) -> dict[str, t.Any]:
+    """Call :meth:`.Schema.execute` and return the data portion of the result.
+    Raise an exception if there are any errors in the result.
+
+    Raises the first error found, even if there are multiple errors.
+
+    If the error is a plain GraphQL error, such as a missing required argument,
+    it is raised directly. If the error is a wrapped exception, indicating an
+    unhandled error in a resolver, the wrapped exception is raised.
+
+    .. versionadded:: 1.1
+    """
+    result = schema.execute(source=source, **kwargs)
+
+    if result.errors:
+        error = result.errors[0]
+
+        if error.original_error:
+            raise error.original_error
+
+        raise error
+
+    assert result.data is not None
+    return result.data
+
+
+def expect_errors(schema: Schema, source: str, **kwargs: t.Any) -> list[GraphQLError]:
+    """Call :meth:`.Schema.execute` and return the errors portion of the result.
+    Raise an error if there is any data in the result, or if there are no errors.
+
+    .. versionadded:: 1.1
+    """
+    result = schema.execute(source=source, **kwargs)
+
+    if result.data is not None:
+        raise ValueError("Expected query to return an error, but it returned data.")
+
+    assert result.errors is not None
+    return result.errors
+
+
+def expect_error(schema: Schema, source: str, **kwargs: t.Any) -> GraphQLError:
+    """Call :meth:`.Schema.execute` and return the single error from the result.
+    Raise an error if there is any data in the result, or if there is not
+    exactly one error.
+
+    .. versionadded:: 1.1
+    """
+    result = expect_errors(schema, source, **kwargs)
+
+    if len(result) > 1:
+        raise ValueError(
+            "Expected query to return a single error, but it returned multiple."
+        )
+
+    return result[0]
+
+
+def expect_validation_error(
+    schema: Schema, source: str, **kwargs: t.Any
+) -> dict[str, t.Any]:
+    """Call :meth:`.Schema.execute` and return the single validation error content
+    from the result. Raise an error if there is any data in the result, or if
+    there is not exactly one validation error.
+
+    .. versionadded:: 1.1
+    """
+    result = expect_error(schema, source, **kwargs)
+
+    if result.message != "magql argument validation":
+        raise ValueError("Expected a validation error.")
+
+    assert result.extensions is not None
+    return result.extensions

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import graphql
 
 import magql
+from magql.testing import expect_data
 
 
 @dataclasses.dataclass()
@@ -21,8 +22,8 @@ def test_default_resolve() -> None:
     root.user = User(1, "abc")
     s = magql.Schema(types=[magql.Object("User", fields={"name": "String"})])
     s.query.fields["user"] = magql.Field("User")
-    result = s.execute("{ user { name } }", root)
-    assert result.data == {"user": {"name": "abc"}}
+    result = expect_data(s, "{ user { name } }", root=root)
+    assert result == {"user": {"name": "abc"}}
 
 
 def test_arg() -> None:
@@ -36,9 +37,8 @@ def test_arg() -> None:
     ) -> User | None:
         return users.get(kwargs["id"])
 
-    result = s.execute("{ user(id: 1) { name } }")
-    assert result.errors is None
-    assert result.data == {"user": {"name": "abc"}}
+    result = expect_data(s, "{ user(id: 1) { name } }")
+    assert result == {"user": {"name": "abc"}}
 
 
 def test_resolver_decorator() -> None:
@@ -53,6 +53,5 @@ def test_resolver_decorator() -> None:
     ) -> User | None:
         return users.get(kwargs["id"])
 
-    result = s.execute("{ user(id: 1) { name } }")
-    assert result.errors is None
-    assert result.data == {"user": {"name": "abc"}}
+    result = expect_data(s, "{ user(id: 1) { name } }")
+    assert result == {"user": {"name": "abc"}}


### PR DESCRIPTION
Adds a `testing` module with the following functions:

- `expect_data` returns `result.data` or raises the first error (the wrapped error if it's unhandled)
- `expect_errors` returns `result.errors` or raises if data is present
- `expect_error` returns a single error
- `expect_validation_error` checks that the single error has the `magql argument validation` message and returns `error.extensions` (the messages).

Uses these functions in the tests.

closes #86 